### PR TITLE
Test Fix: Fix mmap-unmap test.

### DIFF
--- a/src/tests/vm/mmap-unmap.c
+++ b/src/tests/vm/mmap-unmap.c
@@ -17,6 +17,9 @@ test_main (void)
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
   CHECK ((map = mmap (handle, ACTUAL)) != MAP_FAILED, "mmap \"sample.txt\"");
 
+  /* Enforce a page-in so that the PTE is actually created. */
+  volatile int tmp UNUSED = *(int *) ACTUAL;
+
   munmap (map);
 
   fail ("unmapped memory is readable (%d)", *(int *) ACTUAL);


### PR DESCRIPTION
The original test does not enforce a page-in before unmap, making the memory access check after unmap a no-op if page was load lazily.

Fix: add an extra memory access before unmap to enforce a page-in.